### PR TITLE
Add sort by tool in library page

### DIFF
--- a/client/src/components/filter_by_category/styles.css
+++ b/client/src/components/filter_by_category/styles.css
@@ -1,6 +1,7 @@
 .filter-by-category-wrapper {
     border: solid var(--yellow) 1px;
     height: fit-content;
+    margin: 1rem;
 }
 
 .filter-by-category-wrapper h2 {
@@ -18,6 +19,7 @@
     display: flex;
     align-items: center;
     margin: 0.3rem 0;
+    color:#999999;
 }
 
 .filter-by-category-wrapper .input-wrapper input {

--- a/client/src/components/sort_by/index.tsx
+++ b/client/src/components/sort_by/index.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import SortEnum from '../../types/SortByEnum'
+import './styles.css'
+
+export interface SorterProps {
+    onChange: (value: SortEnum) => void
+}
+
+const Sorter: React.FC<SorterProps> = ({ onChange }) => {
+
+    const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+        let selected = (event.target.value) as SortEnum;
+        onChange(selected);
+    }
+
+    return (
+        <div className="sorter-wrapper">
+            <h2>Ordenar por</h2>
+            <select name="sort-by" id="sort-by" className="sort-by-select" onChange={handleChange}>
+                <option key={SortEnum.ALPHABETICAL_ASC} value={SortEnum.ALPHABETICAL_ASC}>Alfabético (A-Z)</option>
+                <option key={SortEnum.ALPHABETICAL_DESC} value={SortEnum.ALPHABETICAL_DESC}>Alfabético (Z-A)</option>
+                <option key={SortEnum.DATE_ASC} value={SortEnum.DATE_ASC}>Mais recente</option>
+                <option key={SortEnum.DATE_DESC} value={SortEnum.DATE_DESC}>Mais antigo</option>
+            </select>
+        </div>
+    )
+}
+export default Sorter

--- a/client/src/components/sort_by/styles.css
+++ b/client/src/components/sort_by/styles.css
@@ -1,0 +1,22 @@
+.sorter-wrapper {
+    border: solid var(--yellow) 1px;
+    height: fit-content;
+    margin: 1rem;
+}
+
+.sorter-wrapper h2 {
+    font-size: 1rem;
+    padding: 0.5rem;
+    color: var(--black);
+    background-color: var(--yellow);
+}
+
+.sorter-wrapper .sort-by-select {
+    margin-right: 0.5rem;
+    font-size: 1rem;
+    background-color:transparent;
+    color:#999999;
+    list-style:none;
+    border: 0;
+    padding: 0.5rem;
+}

--- a/client/src/types/SortByEnum.ts
+++ b/client/src/types/SortByEnum.ts
@@ -1,0 +1,9 @@
+
+enum SortEnum {
+    ALPHABETICAL_ASC = "Alphabetical (A-Z)",
+    ALPHABETICAL_DESC = "Alphabetical (Z-A)",
+    DATE_ASC = "Recent",
+    DATE_DESC = "Older"
+};
+
+export default SortEnum;

--- a/client/src/view/library/index.tsx
+++ b/client/src/view/library/index.tsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react'
 import FilterByCategory from '../../components/filter_by_category'
 import GameItem from '../../components/GameItem';
+import Sorter from '../../components/sort_by';
+import SortEnum from '../../types/SortByEnum';
 import { TPurchasedGame } from '../../types/TGame';
+import { LibraryContainer, ToolsContainer } from './styles';
 
 function loadGamesBoughtFromLocalStorage(): TPurchasedGame[] {
     const gamesBoughtFromStorage = localStorage.getItem('games-bought')
@@ -22,6 +25,7 @@ const Library: React.FC = () => {
     const [games] = useState<TPurchasedGame[]>(loadGamesBoughtFromLocalStorage());
     const [categories] = useState<string[]>(getCategoriesFromGames(games))
     const [selectedCategories, setSelectedCategories] = useState<string[]>([])
+    const [sort, setSelectedSort] = useState<SortEnum>(SortEnum.ALPHABETICAL_ASC)
 
     function filterCategories(categories: string[], games: TPurchasedGame[]) {
         if (categories.length === 0)
@@ -29,24 +33,49 @@ const Library: React.FC = () => {
         return games.filter(g => g.game.categories.some(c => categories.includes(c)))
     }
 
+    function compareDate(d1: Date, d2: Date): number {
+        return (new Date(d1).getTime() - new Date(d2).getTime());
+    }
+
+    function SortBy(sort: SortEnum, games: TPurchasedGame[]): TPurchasedGame[] {
+        console.log("SortBy= " + sort)
+        if (sort === SortEnum.ALPHABETICAL_ASC)
+            return games.sort((a, b) => a.game.name.localeCompare(b.game.name));
+        if (sort === SortEnum.ALPHABETICAL_DESC)
+            return games.sort((a, b) => b.game.description.localeCompare(a.game.description))
+        if (sort === SortEnum.DATE_DESC)
+            return games.sort((a, b) => compareDate(a.purchasedAt, b.purchasedAt));
+        // if (sort === SortEnum.DATE_ASC)
+        return games.sort((a, b) => compareDate(b.purchasedAt, a.purchasedAt));
+    }
+
     return (
         <div>
             <h1 className="page-title">Library</h1>
 
-            <FilterByCategory
-                categories={categories}
-                onChange={newList => setSelectedCategories(newList)}
-            />
+            <LibraryContainer>
+                <ToolsContainer>
+                    <FilterByCategory
+                        categories={categories}
+                        onChange={newList => setSelectedCategories(newList)}
+                    />
 
-            <div className="game-list-box">
-                {filterCategories(selectedCategories, games)
-                    .map(game =>
-                        <GameItem
-                            key={game.game.name}
-                            game={game.game}
-                            purchasedAt={game.purchasedAt}
-                        />)}
-            </div>
+                    <Sorter
+                        onChange={sort => setSelectedSort(sort)}
+                    />
+                </ToolsContainer>
+
+                <div className="game-list-box">
+                    {SortBy(sort,
+                        filterCategories(selectedCategories, games))
+                        .map(game =>
+                            <GameItem
+                                key={game.game.name}
+                                game={game.game}
+                                purchasedAt={game.purchasedAt}
+                            />)}
+                </div>
+            </LibraryContainer>
         </div>
     )
 }

--- a/client/src/view/library/styles.ts
+++ b/client/src/view/library/styles.ts
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const LibraryContainer = styled.div`
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: space-between;
+`;
+
+export const ToolsContainer = styled.div`
+    width: 30%;
+`;


### PR DESCRIPTION
- Adiciona a possibilidade de ordenar os jogos por
  - Ordem alfabética (normal e inversa)
  - Data de compra (recente e antigo)
- Organiza o layout pras ferramentas de busca ficarem no lado direito da tela conforme o protótipo
- Altera cor das ferramentas para cinza, conforme protótipo

### Ordem alfabética (A-Z)
<img width="1786" alt="Screen Shot 2021-10-29 at 14 04 34" src="https://user-images.githubusercontent.com/11835357/139474861-47458a07-b309-46c0-9513-2e6461911e3c.png">

### Ordem alfabética (Z-A)
<img width="1786" alt="Screen Shot 2021-10-29 at 14 08 04" src="https://user-images.githubusercontent.com/11835357/139475296-26894770-756a-4ef3-a8e8-cf41cbd3d52f.png">

### Mais recente
<img width="1786" alt="Screen Shot 2021-10-29 at 14 08 26" src="https://user-images.githubusercontent.com/11835357/139475336-deea4429-4017-47c3-84ea-529ea5e70dee.png">

### Mais antigo
<img width="1786" alt="Screen Shot 2021-10-29 at 14 08 39" src="https://user-images.githubusercontent.com/11835357/139475371-eec0e9c3-ec8f-457c-90a1-6c02f9ea452c.png">

### Funciona junto com o filtro de categorias
<img width="1786" alt="Screen Shot 2021-10-29 at 14 09 57" src="https://user-images.githubusercontent.com/11835357/139475538-4d358b5f-6819-4fba-a168-7325a97ed034.png">
